### PR TITLE
Docs Quickfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ TODO: Pre-compiled release binaries.
 
 ## API
 
-AWDB's API is documented with the OpenAPI specification [here](api/openapi-spec/awdb.yml). You can browse the documentation online [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/RightMesh/awdb/api/openapi-spec/awdb.yml).
+AWDB's API is documented with the OpenAPI specification [here](api/openapi-spec/awdb.yml). You can browse the documentation online [here](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/RightMesh/awdb/master/api/openapi-spec/awdb.yml).

--- a/api/openapi-spec/awdb.yml
+++ b/api/openapi-spec/awdb.yml
@@ -58,14 +58,14 @@ paths:
         500:
           description: Error encoding JSON.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
                 description: Error message from Go.
         502:
           description: Error communicating with ADB.
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
                 description: Error message from Go.


### PR DESCRIPTION
This PR fixes the link to preview the OpenAPI spec, and fixes the content type for error for the `/devices` endpoint.