### PR TITLE
Automated Releases with Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: GoReleaser
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@master
+
+    - name: goreleaser
+      uses: docker://goreleaser/goreleaser
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: release
+      if: success()

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+project_name: awdb
+
+builds:
+- env:
+  - CGO_ENABLED=0
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - 386
+    - amd64
+    - arm
+    - arm64
+
+archives:
+- replacements:
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+  format_overrides:
+    - goos: windows
+      format: zip
+
+nfpms:
+  - replacements:
+      amd64: 64-bit
+      386: 32-bit
+    vendor: RightMesh
+    maintainer: Frazer Seymour <frazer@rightmesh.io>
+    description: An HTTP API wrapping the Android Debug Bridge.
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    dependencies:
+      - android-tools

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ It aims to make it easier to use remote Android devices for testing and debuggin
 
 ## Installation
 
-AWDB can be installed by calling `go get github.com/rightmesh/awdb`. It requires ADB to be installed.
+Compiled binaries and installation packages can be found on the [releases page](https://github.com/RightMesh/awdb/releases).
 
-Once installed, run AWDB with `$GOPATH/bin/awdb`, or just `awdb` if `$GOBIN` is on your `$PATH`.
+AWDB can be installed from source by calling `go get github.com/rightmesh/awdb`.
+
+AWDB depends on the ADB utility being present.
 
 **Note:** AWDB does not have any built-in security or authentication. Ensure any servers running AWDB are behind a firewall and/or reverse proxy with sufficient security features to prevent unauthorized access to your devices.
-
-TODO: Pre-compiled release binaries.
 
 ## API
 


### PR DESCRIPTION
This PR configures Goreleaser to run as an Action whenever a new version is tagged, uploading compiled binaries, RPMs, and DEBs for i386, x86_64, and arm versions of Linux, macOS, and Windows.

It also updates the documentation to point to these releases for installation.